### PR TITLE
Add classnames to fix display styles for value radios

### DIFF
--- a/src/pages/manage/items/[itemId].tsx
+++ b/src/pages/manage/items/[itemId].tsx
@@ -164,7 +164,10 @@ function EditItemForm({ item }: EditItemFormProps) {
           <span className="label-text">Value</span>
         </label>
         {Object.values(Value).map((value) => (
-          <label key={value} className="label cursor-pointer">
+          <label
+            key={value}
+            className="label cursor-pointer justify-start gap-3"
+          >
             <input
               type="radio"
               className="radio radio-sm"

--- a/src/pages/manage/items/create.tsx
+++ b/src/pages/manage/items/create.tsx
@@ -174,7 +174,10 @@ const CreateItem: NextPageWithLayout = () => {
             </span>
           </label>
           {Object.values(Value).map((value) => (
-            <label key={value} className="label cursor-pointer">
+            <label
+              key={value}
+              className="label cursor-pointer justify-start gap-3"
+            >
               <input
                 type="radio"
                 className="radio radio-sm"


### PR DESCRIPTION
# Description

I resolved the issue about the display styles for value radios in add item and edit item page.
